### PR TITLE
re-introduce precompilation. (#1470)

### DIFF
--- a/pythonx/UltiSnips/snippet/definition/base.py
+++ b/pythonx/UltiSnips/snippet/definition/base.py
@@ -14,7 +14,8 @@ from UltiSnips.indent_util import IndentUtil
 from UltiSnips.position import Position
 from UltiSnips.text import escape
 from UltiSnips.text_objects import SnippetInstance
-from UltiSnips.text_objects.python_code import SnippetUtilForAction
+from UltiSnips.text_objects.python_code import SnippetUtilForAction, cached_compile
+
 
 __WHITESPACE_SPLIT = re.compile(r"\s")
 
@@ -104,14 +105,26 @@ class SnippetDefinition:
         self._matched = ""
         self._last_re = None
         self._globals = globals
+        self._compiled_globals = None
         self._location = location
-        self._context_code = context
-        self._context = None
-        self._actions = actions or {}
 
         # Make sure that we actually match our trigger in case we are
-        # immediately expanded.
+        # immediately expanded. At this point we don't take into
+        # account a any context code
+        self._context_code = None
         self.matches(self._trigger)
+
+        self._context_code = context
+        if context:
+            self._compiled_context_code = cached_compile(
+                "snip.context = " + context, "<context-code>", "exec"
+            )
+        self._context = None
+        self._actions = actions or {}
+        self._compiled_actions = {
+            action: cached_compile(source, "<action-code>", "exec")
+            for action, source in self._actions.items()
+        }
 
     def __repr__(self):
         return "_SnippetDefinition(%r,%s,%s,%s)" % (
@@ -155,17 +168,11 @@ class SnippetDefinition:
             locals["visual_text"] = visual_content.text
             locals["last_placeholder"] = visual_content.placeholder
 
-        return self._eval_code("snip.context = " + self._context_code, locals).context
+        return self._eval_code(
+            "snip.context = " + self._context_code, locals, self._compiled_context_code
+        ).context
 
-    def _eval_code(self, code, additional_locals={}):
-        code = "\n".join(
-            [
-                "import re, os, vim, string, random",
-                "\n".join(self._globals.get("!p", [])).replace("\r\n", "\n"),
-                code,
-            ]
-        )
-
+    def _eval_code(self, code, additional_locals={}, compiled_code=None):
         current = vim.current
 
         locals = {
@@ -181,14 +188,27 @@ class SnippetDefinition:
         snip = SnippetUtilForAction(locals)
 
         try:
-            exec(code, {"snip": snip, "match": self._last_re})
+            if self._compiled_globals is None:
+                self._precompile_globals()
+            glob = {"snip": snip, "match": self._last_re}
+            exec(self._compiled_globals, glob)
+            exec(compiled_code or code, glob)
         except Exception as e:
+            code = "\n".join(
+                [
+                    "import re, os, vim, string, random",
+                    "\n".join(self._globals.get("!p", [])).replace("\r\n", "\n"),
+                    code,
+                ]
+            )
             self._make_debug_exception(e, code)
             raise
 
         return snip
 
-    def _execute_action(self, action, context, additional_locals={}):
+    def _execute_action(
+        self, action, context, additional_locals={}, compiled_action=None
+    ):
         mark_to_use = "`"
         with vim_helper.save_mark(mark_to_use):
             vim_helper.set_mark_from_pos(mark_to_use, vim_helper.get_cursor_pos())
@@ -199,7 +219,7 @@ class SnippetDefinition:
 
             locals.update(additional_locals)
 
-            snip = self._eval_code(action, locals)
+            snip = self._eval_code(action, locals, compiled_action)
 
             if snip.cursor.is_set():
                 vim_helper.buf.cursor = Position(
@@ -250,6 +270,18 @@ class SnippetDefinition:
         )
 
         e.snippet_code = code
+
+    def _precompile_globals(self):
+        self._compiled_globals = cached_compile(
+            "\n".join(
+                [
+                    "import re, os, vim, string, random",
+                    "\n".join(self._globals.get("!p", [])).replace("\r\n", "\n"),
+                ]
+            ),
+            "<global-snippets>",
+            "exec",
+        )
 
     def has_option(self, opt):
         """Check if the named option is set."""
@@ -395,7 +427,10 @@ class SnippetDefinition:
             locals = {"buffer": vim_helper.buf, "visual_content": visual_content}
 
             snip = self._execute_action(
-                self._actions["pre_expand"], self._context, locals
+                self._actions["pre_expand"],
+                self._context,
+                locals,
+                self._compiled_actions["pre_expand"],
             )
             self._context = snip.context
             return snip.cursor.is_set()
@@ -411,7 +446,10 @@ class SnippetDefinition:
             }
 
             snip = self._execute_action(
-                self._actions["post_expand"], snippets_stack[-1].context, locals
+                self._actions["post_expand"],
+                snippets_stack[-1].context,
+                locals,
+                self._compiled_actions["post_expand"],
             )
 
             snippets_stack[-1].context = snip.context
@@ -437,7 +475,10 @@ class SnippetDefinition:
             }
 
             snip = self._execute_action(
-                self._actions["post_jump"], current_snippet.context, locals
+                self._actions["post_jump"],
+                current_snippet.context,
+                locals,
+                self._compiled_actions["post_jump"],
             )
 
             current_snippet.context = snip.context
@@ -474,6 +515,8 @@ class SnippetDefinition:
             initial_text.append(result_line)
         initial_text = "\n".join(initial_text)
 
+        if self._compiled_globals is None:
+            self._precompile_globals()
         snippet_instance = SnippetInstance(
             self,
             parent,
@@ -484,6 +527,7 @@ class SnippetDefinition:
             last_re=self._last_re,
             globals=self._globals,
             context=self._context,
+            _compiled_globals=self._compiled_globals,
         )
         self.instantiate(snippet_instance, initial_text, indent)
         snippet_instance.replace_initial_text(vim_helper.buf)

--- a/pythonx/UltiSnips/snippet/source/file/base.py
+++ b/pythonx/UltiSnips/snippet/source/file/base.py
@@ -82,3 +82,6 @@ class SnippetFileSource(SnippetSource):
                 self._snippets[ft].add_snippet(snippet)
             else:
                 assert False, "Unhandled %s: %r" % (event, data)
+        # precompile global snippets code for all snipepts we just sourced
+        for snippet in self._snippets[ft]:
+            snippet._precompile_globals()

--- a/pythonx/UltiSnips/snippet/source/snippet_dictionary.py
+++ b/pythonx/UltiSnips/snippet/source/snippet_dictionary.py
@@ -58,3 +58,6 @@ class SnippetDictionary:
 
     def __len__(self):
         return len(self._snippets)
+
+    def __iter__(self):
+        return iter(self._snippets)

--- a/pythonx/UltiSnips/text_objects/python_code.py
+++ b/pythonx/UltiSnips/text_objects/python_code.py
@@ -12,6 +12,15 @@ from UltiSnips.text_objects.base import NoneditableTextObject
 from UltiSnips.vim_state import _Placeholder
 import UltiSnips.snippet_manager
 
+# We'll end up compiling the global snippets for every snippet so
+# caching compile() should pay off
+from functools import lru_cache
+
+
+@lru_cache(maxsize=None)
+def cached_compile(*args):
+    return compile(*args)
+
 
 class _Tabs:
 
@@ -242,10 +251,18 @@ class PythonCode(NoneditableTextObject):
         self._snip = SnippetUtil(token.indent, mode, text, context, snippet)
 
         self._codes = (
-            "import re, os, vim, string, random",
-            "\n".join(snippet.globals.get("!p", [])).replace("\r\n", "\n"),
+            "import re, os, vim, string, random\n"
+            + "\n".join(snippet.globals.get("!p", [])).replace("\r\n", "\n"),
             token.code.replace("\\`", "`"),
         )
+        self._compiled_codes = (
+            snippet._compiled_globals
+            or cached_compile(self._codes[0], "<exec-globals>", "exec"),
+            cached_compile(
+                token.code.replace("\\`", "`"), "<exec-interpolation-code>", "exec"
+            ),
+        )
+
         NoneditableTextObject.__init__(self, parent, token)
 
     def _update(self, done, buf):
@@ -263,9 +280,9 @@ class PythonCode(NoneditableTextObject):
         )
         self._snip._reset(ct)  # pylint:disable=protected-access
 
-        for code in self._codes:
+        for code, compiled_code in zip(self._codes, self._compiled_codes):
             try:
-                exec(code, self._locals)  # pylint:disable=exec-used
+                exec(compiled_code, self._locals)  # pylint:disable=exec-used
             except Exception as exception:
                 exception.snippet_code = code
                 raise

--- a/pythonx/UltiSnips/text_objects/snippet_instance.py
+++ b/pythonx/UltiSnips/text_objects/snippet_instance.py
@@ -33,6 +33,7 @@ class SnippetInstance(EditableTextObject):
         last_re,
         globals,
         context,
+        _compiled_globals=None,
     ):
         if start is None:
             start = Position(0, 0)
@@ -44,6 +45,7 @@ class SnippetInstance(EditableTextObject):
         self.context = context
         self.locals = {"match": last_re, "context": context}
         self.globals = globals
+        self._compiled_globals = _compiled_globals
         self.visual_content = visual_content
         self.current_placeholder = None
 

--- a/test/test_ParseSnippets.py
+++ b/test/test_ParseSnippets.py
@@ -236,6 +236,31 @@ class ParseSnippets_MultiWord_UnmatchedContainer(_VimTest):
     expected_error = "Invalid multiword trigger: '!inv snip/' in \S+:2"
 
 
+class ParseSnippets_Global_Python_After(_VimTest):
+    files = {
+        "us/all.snippets": r"""
+        snippet ab
+        x `!p snip.rv = tex("bob")` y
+        endsnippet
+
+        context "always()"
+        snippet ac
+        x `!p snip.rv = tex("jon")` y
+        endsnippet
+
+        global !p
+        def tex(ins):
+            return "a " + ins + " b"
+
+        def always():
+            return True
+        endglobal
+        """
+    }
+    keys = "ab" + EX + "\nac" + EX
+    wanted = "x a bob b y\nx a jon b y"
+
+
 class ParseSnippets_Global_Python(_VimTest):
     files = {
         "us/all.snippets": r"""


### PR DESCRIPTION
Global snippets are not compiled in the `__init__` of `SnippetDefinition`, but separately when `_precompile_globals()` is called. Snippet actions, context code and python interpolation code is
compiled in the corresponding `__init__()` functions.